### PR TITLE
Create unified landing page for statistics applets

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -74,3 +74,27 @@ body {
 }
 
 
+
+.nav-bar {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding: 10px;
+  background-color: #f0f0f0;
+}
+
+.nav-bar button {
+  padding: 10px 15px;
+  cursor: pointer;
+}
+
+.iframe-container {
+  flex: 1;
+}
+
+.iframe-container iframe {
+  width: 100%;
+  height: 100%;
+  border: none;
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Statistics Applets</title>
+  <link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+  <div class="nav-bar">
+    <button data-src="html/binomial-normal-explorer.html">Binomial & Normal Explorer</button>
+    <button data-src="html/binomial-components-explorer.html">Binomial Components</button>
+    <button data-src="html/chi-squared-explorer.html">Chi-Squared Explorer</button>
+    <button data-src="html/f-distribution-explorer.html">F Distribution Explorer</button>
+    <button data-src="html/correlation.html">Correlation</button>
+    <button data-src="html/one-sample-z-test.html">One-Sample Z Test</button>
+    <button data-src="html/one-sample-t-test.html">One-Sample t Test</button>
+    <button data-src="html/independent-samples-t-test.html">Independent Samples t Test</button>
+    <button data-src="html/t-distribution-explorer.html">t Distribution Explorer</button>
+  </div>
+  <div class="iframe-container">
+    <iframe id="appletFrame" src="html/binomial-normal-explorer.html"></iframe>
+  </div>
+  <script src="javascript/index.js"></script>
+</body>
+</html>

--- a/javascript/index.js
+++ b/javascript/index.js
@@ -1,0 +1,6 @@
+document.querySelectorAll('.nav-bar button').forEach(button => {
+  button.addEventListener('click', () => {
+    const src = button.getAttribute('data-src');
+    document.getElementById('appletFrame').src = src;
+  });
+});


### PR DESCRIPTION
## Summary
- Add `index.html` with navigation bar that loads each statistical applet in an iframe for a cohesive experience.
- Implement simple `javascript/index.js` to switch applets when navigation buttons are clicked.
- Extend shared styles with navigation and iframe container rules.

## Testing
- `npm test` *(fails: Could not read package.json; no tests available)*

------
https://chatgpt.com/codex/tasks/task_e_68b3343ac0a483288eec1358ea2e4c31